### PR TITLE
fixed name of virtual env in activate command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ From the point of view of the course, you can go ahead and ignore them.
 ----
 python -m venv neoflix
 
-source sandbox/bin/activate
+source neoflix/bin/activate
 ----
 
 


### PR DESCRIPTION
looks like at some point the name given to the virtual environment was changed
from sandbox to neoflix but the command to activate the virtual environment was
not updated at the same time