### PR TITLE
Rename venv to match course content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ htmlcov/
 dist/
 build/
 *.egg-info/
-neoflix/
+sandbox/
 .DS_Store
 .env

--- a/README.adoc
+++ b/README.adoc
@@ -28,9 +28,9 @@ From the point of view of the course, you can go ahead and ignore them.
 
 [source,sh]
 ----
-python -m venv neoflix
+python -m venv sandbox
 
-source neoflix/bin/activate
+source sandbox/bin/activate
 ----
 
 


### PR DESCRIPTION
The Python virtual environment's name is sandbox in the course, but it's neoflix in this repo. This PR renames references to the venv in the README for clarity and the .gitignore to prevent git from tracking it