### PR TITLE
Fixed auth.py by removing `.decode()` method

### DIFF
--- a/api/dao/auth.py
+++ b/api/dao/auth.py
@@ -101,7 +101,7 @@ class AuthDAO:
             payload,
             self.jwt_secret,
             algorithm='HS256'
-        ).decode('ascii')
+        )
     # end::generate[]
 
     """


### PR DESCRIPTION
The `jwt.encode()` does not need to additionally call the `.decode("ascii")` method; this causes the training to fail for an issue beyond the scope of the Python Applications lesson.