### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,6 +39,6 @@ source neoflix/bin/activate
 
 [source,sh]
 export FLASK_APP=api
-export FLASK_ENV=development
+export FLASK_DEBUG=True
 flask run
 


### PR DESCRIPTION
While executing `flask run`, a deprecation warning appears indicating that `FLASK_ENV` is deprecated, and it is recommended to use `FLASK_DEBUG` for the development environment.

Updated application running step