### PR TITLE
Update cypher query in find_by_id() and get_similar_people() in people.py

### DIFF
--- a/api/dao/people.py
+++ b/api/dao/people.py
@@ -56,9 +56,9 @@ class PeopleDAO:
             row = tx.run("""
                 MATCH (p:Person {tmdbId: $id})
                 RETURN p {
-                    .*,
-                    actedCount: count {(p)-[:ACTED_IN]->()},
-                    directedCount: count {(p)-[:DIRECTED]->()}
+                .*,
+                actedCount: count {(p)-[:ACTED_IN]->()},
+                directedCount: count {(p)-[:DIRECTED]->()}
                 } AS person
             """, id=id).single()
 
@@ -81,11 +81,12 @@ class PeopleDAO:
         def get_similar_people(tx, id, skip, limit):
             result = tx.run("""
                 MATCH (:Person {tmdbId: $id})-[:ACTED_IN|DIRECTED]->(m)<-[r:ACTED_IN|DIRECTED]-(p)
+                WITH p, collect(m {.tmdbId, .title, type: type(r)}) AS inCommon
                 RETURN p {
-                    .*,
-                    actedCount: count {(p)-[:ACTED_IN]->()},
-                    directedCount: count {(p)-[:DIRECTED]->()},
-                    inCommon: collect(m {.tmdbId, .title, type: type(r)})
+                .*,
+                actedCount: count {(p)-[:ACTED_IN]->()},
+                directedCount: count {(p)-[:DIRECTED]->()},
+                inCommon: inCommon
                 } AS person
                 ORDER BY size(person.inCommon) DESC
                 SKIP $skip

--- a/api/dao/people.py
+++ b/api/dao/people.py
@@ -57,8 +57,8 @@ class PeopleDAO:
                 MATCH (p:Person {tmdbId: $id})
                 RETURN p {
                     .*,
-                    actedCount: size((p)-[:ACTED_IN]->()),
-                    directedCount: size((p)-[:DIRECTED]->())
+                    actedCount: count {(p)-[:ACTED_IN]->()},
+                    directedCount: count {(p)-[:DIRECTED]->()}
                 } AS person
             """, id=id).single()
 
@@ -83,8 +83,8 @@ class PeopleDAO:
                 MATCH (:Person {tmdbId: $id})-[:ACTED_IN|DIRECTED]->(m)<-[r:ACTED_IN|DIRECTED]-(p)
                 RETURN p {
                     .*,
-                    actedCount: size((p)-[:ACTED_IN]->()),
-                    directedCount: size((p)-[:DIRECTED]->()),
+                    actedCount: count {(p)-[:ACTED_IN]->()},
+                    directedCount: count {(p)-[:DIRECTED]->()},
                     inCommon: collect(m {.tmdbId, .title, type: type(r)})
                 } AS person
                 ORDER BY size(person.inCommon) DESC


### PR DESCRIPTION
the size() function no longer works.
Updating as per the correct cypher query mentioned in the course.
Right changes were made in the second commit of this PR.